### PR TITLE
Cosmetics and MINIMAL pragma

### DIFF
--- a/src/Temporal/Class.hs
+++ b/src/Temporal/Class.hs
@@ -1,37 +1,37 @@
 {-# Language TypeFamilies #-}
 module Temporal.Class(
-	DurOf, Duration(..), Melody(..), Harmony(..), Compose(..), 
-	loopBy, melMap, harMap, 
-	Delay(..), (+|),
-	Rest(..), Stretch(..), (*|), Limit(..), 
-	Loop(..)
+   DurOf, Duration(..), Melody(..), Harmony(..), Compose(..),
+   loopBy, melMap, harMap,
+   Delay(..), (+|),
+   Rest(..), Stretch(..), (*|), Limit(..),
+   Loop(..)
 ) where
 
 -- | Calculates duration.
 class Duration a where
-	dur :: a -> DurOf a
+   dur :: a -> DurOf a
 
 -- | Duration for the given type.
 type family DurOf a :: *
 
 class Melody a where
-	-- | Sequent composition for a list of values (melody). 
-	mel :: [a] -> a
-	-- | Sequent composition. Play first track then second.
-	(+:+) :: a -> a -> a
+   -- | Sequent composition for a list of values (melody).
+   mel :: [a] -> a
+   -- | Sequent composition. Play first track then second.
+   (+:+) :: a -> a -> a
 
-	a +:+ b = mel [a, b]
-	mel = foldl1 (+:+)
+   a +:+ b = mel [a, b]
+   mel = foldl1 (+:+)
 
 class Harmony a where
-	-- | Parallel composition for a list of values (harmony). 
-	har :: [a] -> a
+   -- | Parallel composition for a list of values (harmony).
+   har :: [a] -> a
 
-	-- | Parallel composition. Play two tracks simultaneously.
-	(=:=) :: a -> a -> a
+   -- | Parallel composition. Play two tracks simultaneously.
+   (=:=) :: a -> a -> a
 
-	a =:= b = har [a, b]
-	har = foldl1 (=:=)
+   a =:= b = har [a, b]
+   har = foldl1 (=:=)
 
 
 class (Melody a, Harmony a) => Compose a where
@@ -41,12 +41,12 @@ loopBy :: Melody a => Int -> a -> a
 loopBy n = mel . replicate n
 
 class Delay a where
-	-- | Delays the sound source by the given duration.
-	del :: DurOf a -> a -> a
+   -- | Delays the sound source by the given duration.
+   del :: DurOf a -> a -> a
 
 class Stretch a where
-	-- | Delays the sound source by the given duration factor.
-	str :: DurOf a -> a -> a
+   -- | Delays the sound source by the given duration factor.
+   str :: DurOf a -> a -> a
 
 -- | Infix 'del' function.
 (+|) :: Delay a => DurOf a -> a -> a
@@ -57,15 +57,15 @@ class Stretch a where
 (*|) = str
 
 class Rest a where
-	rest :: DurOf a -> a
+   rest :: DurOf a -> a
 
 class Limit a where
-	-- | Limits the duration of the sound source.
-	lim :: DurOf a -> a -> a
+   -- | Limits the duration of the sound source.
+   lim :: DurOf a -> a -> a
 
 class Loop a where
-	-- | Loops over the sound
-	loop :: a -> a
+   -- | Loops over the sound
+   loop :: a -> a
 
 -- | Transforms a sequence and then applies a mel.
 melMap :: (Melody b) => (a -> b) -> [a] -> b

--- a/src/Temporal/Class.hs
+++ b/src/Temporal/Class.hs
@@ -22,6 +22,7 @@ class Melody a where
 
    a +:+ b = mel [a, b]
    mel = foldl1 (+:+)
+   {-# MINIMAL mel | (+:+) #-}
 
 class Harmony a where
    -- | Parallel composition for a list of values (harmony).
@@ -32,6 +33,7 @@ class Harmony a where
 
    a =:= b = har [a, b]
    har = foldl1 (=:=)
+   {-# MINIMAL har | (=:=) #-}
 
 
 class (Melody a, Harmony a) => Compose a where

--- a/src/Temporal/Media.hs
+++ b/src/Temporal/Media.hs
@@ -94,7 +94,7 @@ instance Num t => Delay (Track t a) where
 
 -- | Turncating parallel composition. Total duration
 -- equals to minimum of the two tracks. All events
--- that goes beyond the lmimt are dropped.
+-- that goes beyond the limit are dropped.
 (=:/) :: (Real t, IfB t, OrdB t) => Track t a -> Track t a -> Track t a
 a =:/ b = slice 0 (dur a `minB` dur b) $ a <> b
 
@@ -235,11 +235,11 @@ sustain a = mapEvents $ \e -> e{ eventDur = a + eventDur e }
 
 -- | Prolongated events can not exceed total track duration.
 -- All event are sustained but those that are close to 
--- end of the track are sliceped. It resembles sustain on piano,
+-- end of the track are sliced. It resembles sustain on piano,
 -- when track ends you release the pedal.
 sustainT :: (Ord t, Num t) => t -> Track t a -> Track t a
-sustainT a x = mapEvents (\e -> turncate $ e{ eventDur = a + eventDur e }) x
-    where turncate e
+sustainT a x = mapEvents (\e -> truncate $ e{ eventDur = a + eventDur e }) x
+    where truncate e
             | eventEnd e > d    = e{ eventDur = max 0 $ d - eventStart e }
             | otherwise         = e
           d = dur x


### PR DESCRIPTION
Fix a couple typos and spacing things, and also add ```MINIMAL``` pragma for circular default definitions.